### PR TITLE
Add STT option to assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,16 @@ Poetry for dependency management and pyenv for Python version control.
 ## Running
 
 Use the `scripts/run_assistant.py` script to send a message to the SiliconFlow
-API and print the reply. The reply can also be sent to WeChat with `--wechat`
-and saved as a speech audio file with `--tts`:
+API and print the reply. The reply can also be sent to WeChat with `--wechat`,
+transcribed from an audio file with `--stt`, and saved as a speech audio file
+with `--tts`:
 
 ```bash
 poetry run python scripts/run_assistant.py "Hello" --wechat --tts reply.mp3
+```
+To transcribe audio as the prompt and read the reply aloud:
+```bash
+poetry run python scripts/run_assistant.py --stt question.wav --tts answer.mp3
 ```
 
 ## Testing

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,9 +17,13 @@ Copy `config_template.yaml` to `config.yaml` and provide your SiliconFlow API to
 
 ## Running
 
-You can send a prompt to the assistant and optionally relay the response to the active WeChat chat window. The reply can also be saved as an audio file using `--tts`:
+You can send a prompt to the assistant and optionally relay the response to the active WeChat chat window. The prompt may come from an audio file using `--stt`, and the reply can also be saved as an audio file using `--tts`:
 
 ```bash
 poetry run python scripts/run_assistant.py "Hello" --wechat --tts reply.mp3
+```
+To transcribe audio as the prompt and save the reply as an audio file:
+```bash
+poetry run python scripts/run_assistant.py --stt question.wav --tts answer.mp3
 ```
 

--- a/tests/test_run_assistant.py
+++ b/tests/test_run_assistant.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import scripts.run_assistant as ra
+
+
+def test_run_assistant_stt(tmp_path, capsys):
+    audio = tmp_path / "audio.wav"
+    audio.write_bytes(b"bytes")
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        """
+api:
+  token: T
+  base_url: https://example.com
+models:
+  chat: chat
+  stt: stt
+  tts: tts
+  image: img
+params:
+  temperature: 0.1
+  top_p: 0.2
+  top_k: 5
+  max_tokens: 16
+"""
+    )
+
+    with patch.object(sys, "argv", ["run_assistant.py", "--config", str(cfg), "--stt", str(audio)]), \
+         patch("scripts.run_assistant.SiliconFlowClient") as Client, \
+         patch("wechat_gpt.voice.speech_to_text.speech_to_text", return_value="hi") as stt:
+        instance = Client.return_value
+        instance.chat.return_value = "ok"
+        ra.main()
+        out, _ = capsys.readouterr()
+        assert "Assistant: ok" in out
+        stt.assert_called_once()
+        instance.chat.assert_called_once_with([{"role": "user", "content": "hi"}])


### PR DESCRIPTION
## Summary
- allow `scripts/run_assistant.py` to transcribe audio with `--stt`
- document audio input usage in README and docs
- test the new `--stt` option

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846484c0d288320b067fee23eabaf38