### PR TITLE
Add tests for wechat and tts options

### DIFF
--- a/tests/test_run_assistant.py
+++ b/tests/test_run_assistant.py
@@ -37,3 +37,69 @@ params:
         assert "Assistant: ok" in out
         stt.assert_called_once()
         instance.chat.assert_called_once_with([{"role": "user", "content": "hi"}])
+
+
+def test_run_assistant_wechat(tmp_path, capsys):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        """
+api:
+  token: T
+  base_url: https://example.com
+models:
+  chat: chat
+  stt: stt
+  tts: tts
+  image: img
+params:
+  temperature: 0.1
+  top_p: 0.2
+  top_k: 5
+  max_tokens: 16
+"""
+    )
+
+    with patch.object(sys, "argv", ["run_assistant.py", "--config", str(cfg), "--wechat", "hi"]), \
+         patch("scripts.run_assistant.SiliconFlowClient") as Client, \
+         patch("wechat_gpt.wechat.client.send_message") as send:
+        instance = Client.return_value
+        instance.chat.return_value = "ok"
+        ra.main()
+        out, _ = capsys.readouterr()
+        assert "Assistant: ok" in out
+        send.assert_called_once_with("ok")
+        instance.chat.assert_called_once_with([{"role": "user", "content": "hi"}])
+
+
+def test_run_assistant_tts(tmp_path, capsys):
+    output = tmp_path / "speech.wav"
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        """
+api:
+  token: T
+  base_url: https://example.com
+models:
+  chat: chat
+  stt: stt
+  tts: tts
+  image: img
+params:
+  temperature: 0.1
+  top_p: 0.2
+  top_k: 5
+  max_tokens: 16
+"""
+    )
+
+    with patch.object(sys, "argv", ["run_assistant.py", "--config", str(cfg), "--tts", str(output), "hi"]), \
+         patch("scripts.run_assistant.SiliconFlowClient") as Client, \
+         patch("wechat_gpt.voice.text_to_speech.text_to_speech", return_value=b"audio") as tts:
+        instance = Client.return_value
+        instance.chat.return_value = "ok"
+        ra.main()
+        out, _ = capsys.readouterr()
+        assert "Assistant: ok" in out
+        tts.assert_called_once_with(instance, "ok")
+        assert output.read_bytes() == b"audio"
+        instance.chat.assert_called_once_with([{"role": "user", "content": "hi"}])


### PR DESCRIPTION
## Summary
- extend `test_run_assistant.py` to cover `--wechat` and `--tts` flags
- ensure output is written when using `--tts`
- assert `send_message` called with `--wechat`

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684666a86ac48320989491bfeb30a435