### PR TITLE
Fix warning message in client

### DIFF
--- a/wechat_gpt/wechat/client.py
+++ b/wechat_gpt/wechat/client.py
@@ -28,7 +28,6 @@ def send_message(text: str) -> None:
 def get_latest_message() -> str:
     """Placeholder for retrieving the latest message from WeChat."""
     logger.warning(
-        "get_latest_message is not implemented. This requires more complex ClickClick scripting."
+        "get_latest_message is not implemented. More complex ClickClick scripting is required."
     )
-    logger.warning("get_latest_message is not implemented. Returning empty string.")
     return ""


### PR DESCRIPTION
## Summary
- reduce duplicate warnings in `get_latest_message`

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684666a71f588320bb8f8f22f2f2717e